### PR TITLE
redirect page to Ed-DaSH website, fixes #18

### DIFF
--- a/ed-dash/index.html
+++ b/ed-dash/index.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<!–– redirects from https://edcarp.github.io/ed-dash/ (all lower case) to https://edcarp.github.io/Ed-DaSH/ (mixed case) ––>
+<meta charset="utf-8">
+<title>Redirecting to https://edcarp.github.io/Ed-DaSH/</title>
+<meta http-equiv="refresh" content="0; URL=https://edcarp.github.io/Ed-DaSH/">
+<link rel="canonical" href="https://edcarp.github.io/Ed-DaSH/">


### PR DESCRIPTION
Addresses #18, by creating a page at https://edcarp.github.io/ed-dash/ (all lower case, incorrect) that redirects to https://edcarp.github.io/Ed-DaSH/ (mixed case, correct)

Follows the instructions here: https://dev.to/steveblue/setup-a-redirect-on-github-pages-1ok7